### PR TITLE
changed get_type_links and added get_render_links

### DIFF
--- a/eveimageserver/__init__.py
+++ b/eveimageserver/__init__.py
@@ -6,6 +6,7 @@ from .main import (
     get_alliance_links,
     get_faction_links,
     get_type_links,
+    get_render_links,
     get_image_server_link,
 )
 

--- a/eveimageserver/main.py
+++ b/eveimageserver/main.py
@@ -86,7 +86,7 @@ def get_image_server_link(image_id, image_type, icon_size=128):
     Renders: 32, 64, 128, 256, 512
 
     :param image_id: ID to be used in the URL.
-    :param image_type: Valid string options are: char, corp, alli, fac, type
+    :param image_type: Valid string options are: char, corp, alli, fac, type, render
     :param icon_size: See doc string for valid image sizes.
     :return: A full URL to the CCP image server.
     """

--- a/eveimageserver/main.py
+++ b/eveimageserver/main.py
@@ -6,7 +6,8 @@ CHARACTER_SIZES = [32, 64, 128, 256, 512, 1024]
 CORPORATION_SIZES = [32, 64, 128, 256]
 ALLIANCES_SIZES = [32, 64, 128]
 FACTION_SIZES = [32, 64, 128]
-TYPE_SIZES = [32, 64, 128, 256, 512]
+TYPE_SIZES = [32, 64]
+RENDER_SIZES = [32, 64, 128, 256, 512]
 
 def get_character_links(character_id):
     """ Takes a character ID and returns a dict with all available size links.
@@ -62,6 +63,16 @@ def get_type_links(type_id):
 
     return return_dict
 
+def get_render_links(type_id):
+    """ Takes a type ID and returns a dict with all available size links.
+
+    :param type_id: A type ID from EVE.
+    :return: A dict of size and urls.
+    """
+
+    return_dict = {x: get_image_server_link(type_id, 'render', x) for x in RENDER_SIZES}
+
+    return return_dict
 
 def get_image_server_link(image_id, image_type, icon_size=128):
     """Takes an ID and type name and builds and image server URL.
@@ -71,7 +82,8 @@ def get_image_server_link(image_id, image_type, icon_size=128):
     Corporation: 32, 64, 128, 256
     Alliance: 32, 64, 128
     Faction: 32, 64, 128
-    Types: 32, 64, 128, 256, 512
+    Types: 32, 64
+    Renders: 32, 64, 128, 256, 512
 
     :param image_id: ID to be used in the URL.
     :param image_type: Valid string options are: char, corp, alli, fac, type
@@ -95,6 +107,10 @@ def get_image_server_link(image_id, image_type, icon_size=128):
 
     elif image_type == 'fac':
         url_type = 'Alliance'
+        url_format = 'png'
+
+    elif image_type == 'type':
+        url_type = 'Type'
         url_format = 'png'
 
     else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,7 +18,7 @@ class EVEImageServerTestCase(unittest2.TestCase):
         mock_os.return_value = 'http://example.com/'
         image_link = eveimageserver.get_image_server_link(1234, 'type')
 
-        self.assertEqual(image_link, 'http://example.com/Render/1234_128.png')
+        self.assertEqual(image_link, 'http://example.com/Type/1234_128.png')
 
     @mock.patch('os.environ.get')
     def test_get_character_links(self, mock_os):
@@ -94,6 +94,21 @@ class EVEImageServerTestCase(unittest2.TestCase):
 
         mock_os.return_value = 'http://example.com/'
         links = eveimageserver.get_type_links(123456)
+
+        self.assertEqual(
+            links,
+            {
+                32: 'http://example.com/Type/123456_32.png',
+                64: 'http://example.com/Type/123456_64.png',
+            }
+        )
+
+    @mock.patch('os.environ.get')
+    def test_get_render_links(self, mock_os):
+        """ Test get_type_links gets the correct dictionary back. """
+
+        mock_os.return_value = 'http://example.com/'
+        links = eveimageserver.get_render_links(123456)
 
         self.assertEqual(
             links,


### PR DESCRIPTION
changed get_type_links to not longer return links to render images but to the type icons.

new function get_render_links now return links to render images.
